### PR TITLE
TEC-143 add Truste link in Cookie Preferences

### DIFF
--- a/example.es6
+++ b/example.es6
@@ -1,6 +1,11 @@
 import React from 'react';
 import CookieMessage from './';
 
+// this ensures the cookie is never written
+const fakeCookie = {
+  load: () => {},
+  save: () => {},
+};
 export default (
-  <CookieMessage/>
+  <CookieMessage reactCookieInstance={fakeCookie}/>
 );

--- a/index.css
+++ b/index.css
@@ -2,7 +2,7 @@
 @import "@economist/component-palette";
 @import "@economist/component-grid";
 
-.cookie-message--link {
+.cookie-message--link, .cookie-message--link:visited {
   color: inherit;
   text-decoration: none;
   border-bottom: 1px solid var(--color-london);
@@ -39,6 +39,9 @@
   max-width: var(--cookie-message-max-width, 900px);
   margin: auto;
 }
+
+.cookie-message__link--temporary-cookie-preferences { display: none; }
+.cookie-message--link__preferences :only-of-type { display: inline; }
 
 @media screen and (max-width: 820px) {
   .cookie-message--message-container br {

--- a/index.es6
+++ b/index.es6
@@ -1,4 +1,4 @@
-/* global window */
+/* global window document */
 import React from 'react';
 import reactCookie from 'react-cookie';
 import Icon from '@economist/component-icon';
@@ -25,13 +25,22 @@ export default class CookieMessage extends React.Component {
     const isCookieMessageRequired = !cookie.load(this.props.cookieName);
     this.setState({ isCookieMessageRequired });
     if (isCookieMessageRequired) {
-      const isHttps = window.location.href.substr(0, 5) === 'https';
+      const isHttps = window.location.protocol === 'https:';
       const cookieOptions = {
         expires: new Date('01-01-2040'),
         secure: isHttps,
         httpOnly: false,
       };
       cookie.save(this.props.cookieName, '1', cookieOptions);
+    }
+  }
+  componentDidMount() {
+    if (typeof window !== 'undefined' && window.document) {
+      const trusteScript = document.createElement('script');
+      trusteScript.async = true;
+      trusteScript.type = 'text/javascript';
+      trusteScript.src = '//consent.truste.com/notice?domain=economist.com&c=teconsent-preferences&text=true';
+      document.head.appendChild(trusteScript);
     }
   }
   onCloseClick() {
@@ -50,11 +59,16 @@ export default class CookieMessage extends React.Component {
       </a>
     );
     const preferencesLink = (
-      <a href="#"
-        className="cookie-message--link cookie-message--link__preferences"
+      <span id="teconsent-preferences"
+        className="cookie-message--link__preferences cookie-message--link"
       >
-        cookies preferences
-      </a>
+        <a href="http://www.allaboutcookies.org/manage-cookies/"
+          className="cookie-message--link
+          cookie-message__link--temporary-cookie-preferences"
+        >
+          Cookie preferences
+        </a>
+      </span>
     );
     return (
       <div className="cookie-message">


### PR DESCRIPTION
To prevent this script from blocking a page load it's called
asynchronously. This results in requiring a different link for the
duration of the two Truste script requests.

I've opted for a link from http://www.economist.com/cookies-info which
is http://www.allaboutcookies.org/manage-cookies/

Alternatively this could point to the current cookies-info link.
