### PR TITLE
TEC-143 change link text and targets

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -62,11 +62,11 @@ export default class CookieMessage extends React.Component {
       <span id="teconsent-preferences"
         className="cookie-message--link__preferences cookie-message--link"
       >
-        <a href="http://www.allaboutcookies.org/manage-cookies/"
+        <a href="//www.economist.com/cookies-info"
           className="cookie-message--link
           cookie-message__link--temporary-cookie-preferences"
         >
-          Cookie preferences
+          cookies preferences
         </a>
       </span>
     );


### PR DESCRIPTION
This link is hidden by CSS when the Truste script is loaded and subsequently adds its own link.

```css
.cookie-message__link--temporary-cookie-preferences { display: none; }
.cookie-message--link__preferences :only-of-type { display: inline; }
```

Until it is hidden, it now points to the same target as the previous link in the cookie message.