### PR TITLE
CSS fixes: TEC-498, TEC-499, TEC-500

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ document.cookie='ec_cookie_message_0'+'=;Max-Age=0'
 
  - `--cookiemessage-vertical-padding`
  - `--cookiemessage-horizontal-padding`
+ - `--cookiemessage-min-height`
+ - `--cookiemessage-link-hover`

--- a/index.css
+++ b/index.css
@@ -13,7 +13,10 @@
   font-size: var(--text-size-step--2);
   line-height: var(--text-line-height-body-on-step--2);
   padding: var(--cookiemessage-vertical-padding, var(--grid-spacing-sheep)) var(--cookiemessage-horizontal-padding, var(--grid-gutter-s));
+  box-sizing: border-box;
+  min-height: var(--cookiemessage-min-height, 64px);
   background: var(--color-berlin);
+  overflow: hidden;
 }
 
 .cookie-message--close {
@@ -24,10 +27,6 @@
   width: 2em;
 
   fill: var(--color-beijing);
-}
-
-.cookie-message--close:hover {
-  fill: var(--color-london);
 }
 
 .cookie-message--close-wrapper {
@@ -47,16 +46,31 @@
 
 .cookie-message--message-container {
   position: relative;
-  padding-right: var(--grid-spacing-sheep);
-  max-width: var(--cookie-message-max-width, 900px);
-  margin: auto;
+  padding-right: var(--grid-spacing-donkey);
+}
+
+@media screen and (min-width: 1024px) {
+  .cookie-message--message-container {
+    /* Vertically align the cookie message. */
+    top: 0.5em;
+    top: calc(
+      var(--cookiemessage-min-height, 64px) / 2 -
+      var(--cookiemessage-vertical-padding, var(--grid-spacing-sheep)) -
+      0.5em *
+      var(--text-line-height-body-on-step--2)
+    );
+  }
 }
 
 .cookie-message__link--temporary-cookie-preferences { display: none; }
 .cookie-message--link__preferences :only-of-type { display: inline; }
 
-@media screen and (max-width: 820px) {
-  .cookie-message--message-container br {
-    display: none;
-  }
+.cookie-message--link:hover {
+  color: var(--cookiemessage-link-hover, var(--color-chicago));
+  border-bottom: none;
 }
+
+.cookie-message--close-wrapper:hover .cookie-message--close {
+  fill: var(--cookiemessage-link-hover, var(--color-chicago));
+}
+

--- a/index.es6
+++ b/index.es6
@@ -81,7 +81,7 @@ export default class CookieMessage extends React.Component {
             <Icon icon="close" className="cookie-message--close" />
           </span>
           By continuing to browse this site you are agreeing to our use of cookies.
-          Review our <br/>{policyLink} for details or change your {preferencesLink}.
+          Review our {policyLink} for details or change your {preferencesLink}.
         </div>
       </div>
     );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-cookie-message",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Reusable cookie message component",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
   "dependencies": {
     "@economist/component-grid": "^1.3.0",
     "@economist/component-icon": "^5.2.1",
-    "@economist/component-palette": "^1.2.0",
+    "@economist/component-palette": "^1.4.2",
     "@economist/component-typography": "^1.4.4",
     "react-cookie": "^0.3.4"
   },


### PR DESCRIPTION
Cookie-message should be 64px tall, be in one line (no `br`!), and links should have a non-underlined hover state, coloured chicago.