### PR TITLE
WP-1503 prepare for react 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   directories:
     - node_modules
 node_js:
-  - '4'
+  - '6'
   - stable
 after_success: >-
   travis-after-all && npm run semantic-release && npm run pages -- --repo

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -97,5 +97,14 @@ module.exports = function configureKarma(config) {
         build: configureBuildValue(),
       },
     });
+  } else {
+    config.set({
+      files: [
+        // We want to add the polyfill specifically to phantomjs,
+        // because it does not support some of the es6 features, e.g. Map().
+        'node_modules/babel-polyfill/browser.js',
+        path.join(packageJson.directories.test, '*.js'),
+      ],
+    });
   }
 };

--- a/package.json
+++ b/package.json
@@ -102,8 +102,11 @@
   },
   "dependencies": {
     "@economist/component-icon": "^5.2.1",
-    "react": "^0.14.8||^15.0.0",
-    "react-cookie": "^0.4.5"
+    "react-cookie": "^0.4.5",
+    "prop-types": "^15.5.0"
+  },
+  "peerDependencies": {
+    "react": "^16.0.0"
   },
   "devDependencies": {
     "@economist/component-grid": "^1.3.2",
@@ -122,10 +125,8 @@
     "browserify": "^13.0.0",
     "browserify-istanbul": "^2.0.0",
     "chai": "^3.5.0",
-    "chai-enzyme": "^0.4.2",
     "chai-spies": "^0.7.1",
     "coveralls": "^2.11.9",
-    "enzyme": "^2.2.0",
     "eslint": "^2.9.0",
     "eslint-config-strict": "^8.5.1",
     "eslint-config-strict-react": "^8.0.1",
@@ -154,8 +155,8 @@
     "postcss-import": "^8.1.0",
     "postcss-reporter": "^1.3.3",
     "postcss-url": "^5.1.1",
-    "react-addons-test-utils": "^0.14.8||^15.0.0",
-    "react-dom": "^0.14.8||^15.0.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "semantic-release": "^4.3.5",
     "stylelint": "^6.2.2",
     "stylelint-config-strict": "^5.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
- /* global window document */
+/* global window document */
 import React from 'react';
+import PropTypes from 'prop-types';
 import reactCookie from 'react-cookie';
 import Icon from '@economist/component-icon';
 
@@ -100,13 +101,13 @@ export default class CookieMessage extends React.Component {
 
 if (process.env.NODE_ENV !== 'production') {
   CookieMessage.propTypes = {
-    cookieName: React.PropTypes.string,
-    reactCookieInstance: React.PropTypes.shape({
-      load: React.PropTypes.func.isRequired,
-      save: React.PropTypes.func.isRequired,
+    cookieName: PropTypes.string,
+    reactCookieInstance: PropTypes.shape({
+      load: PropTypes.func.isRequired,
+      save: PropTypes.func.isRequired,
     }),
-    renderCloseButton: React.PropTypes.func,
-    renderPolicyLink: React.PropTypes.func,
-    renderPreferencesLink: React.PropTypes.func,
+    renderCloseButton: PropTypes.func,
+    renderPolicyLink: PropTypes.func,
+    renderPreferencesLink: PropTypes.func,
   };
 }


### PR DESCRIPTION
A note from me:

- After upgrading to React 16, beloved PhantomJS started to act up, complaining about Map. Apparently it's a common problem, which seems to be circumvented by adding polyfill for Phantom. I have changed the Karma config accordingly, taking care not to add the polyfill to Saucelabs config.