### PR TITLE
WP-1503 test(polyfill): add babel-polyfill to karma (SauceLabs as well as local)

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -48,6 +48,7 @@ module.exports = function configureKarma(config) {
     logLevel: config.LOG_INFO,
     frameworks: [ 'browserify', 'mocha' ],
     files: [
+      'node_modules/babel-polyfill/browser.js',
       path.join(packageJson.directories.test, '*.js'),
     ],
     exclude: [],
@@ -96,15 +97,6 @@ module.exports = function configureKarma(config) {
         startConnect: true,
         build: configureBuildValue(),
       },
-    });
-  } else {
-    config.set({
-      files: [
-        // We want to add the polyfill specifically to phantomjs,
-        // because it does not support some of the es6 features, e.g. Map().
-        'node_modules/babel-polyfill/browser.js',
-        path.join(packageJson.directories.test, '*.js'),
-      ],
     });
   }
 };


### PR DESCRIPTION
It turns out Safari 7 does not like Map() either. I have looked at other components, and they seem to be combating the issue by importing 'babel-polyfill' directly in the test files. Instead, I have simply added 'babel-polyfill' to all karma runs (local and SauceLabs).

Here is the output from the build after merging:

![image](https://user-images.githubusercontent.com/3444125/32847170-24ab6f78-ca21-11e7-939a-311f4b52aaa8.png)
